### PR TITLE
Reload should start if it's not running

### DIFF
--- a/SOURCES/haproxy.init
+++ b/SOURCES/haproxy.init
@@ -89,7 +89,7 @@ restart() {
 
 reload() {
   if ! [ -s $PIDFILE ]; then
-    return 0
+    start
   fi
 
   quiet_check


### PR DESCRIPTION
Consul causes lots of reloads, we can use this process to make sure that haproxy-egress starts if it's not running.